### PR TITLE
Follow "Logger" Inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ require "redacting_logger"
 
 # Create a new logger
 logger = RedactingLogger.new(
+  $stdout, # The device to log to (defaults to $stdout if not provided)
   redact_patterns: [/REDACTED_PATTERN1/, /REDACTED_PATTERN2/], # An array of Regexp patterns to redact from the logs
-  log_device: $stdout, # The device to log to
   level: Logger::INFO, # The log level to use
   redacted_msg: "[REDACTED]", # The message to replace the redacted patterns with
   use_default_patterns: true # Whether to use the default built-in patterns or not

--- a/lib/redacting_logger.rb
+++ b/lib/redacting_logger.rb
@@ -8,19 +8,25 @@ require_relative "patterns/default"
 class RedactingLogger < Logger
   # Initializes a new instance of the RedactingLogger class.
   #
+  # @param logdev [Object] The log device. Defaults to $stdout.
+  # @param shift_age [Integer] The number of old log files to keep.
+  # @param shift_size [Integer] The maximum logfile size.
   # @param redact_patterns [Array<String>] The patterns to redact from the log messages. Defaults to [].
-  # @param log_device [Object] The log device (file, STDOUT, etc.) to write to. Defaults to STDOUT.
   # @param redacted_msg [String] The message to replace the redacted patterns with.
   # @param use_default_patterns [Boolean] Whether to use the default patterns or not.
   # @param kwargs [Hash] Additional options to pass to the Logger class.
+  #
+  # logdev, shift_age, and shift_size are all using the defaults from the standard Logger class. -> https://github.com/ruby/logger/blob/0996f90650fd95718f0ffe835b965de18654b71c/lib/logger.rb#L578-L580
   def initialize(
+    logdev = $stdout,
+    shift_age = 0,
+    shift_size = 1048576,
     redact_patterns: [],
-    log_device: $stdout,
     redacted_msg: "[REDACTED]",
     use_default_patterns: true,
     **kwargs
   )
-    super(log_device, **kwargs)
+    super(logdev, **kwargs)
     @redact_patterns = redact_patterns
     @redacted_msg = redacted_msg
     @redact_patterns += Patterns::DEFAULT if use_default_patterns

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,6 +2,6 @@
 
 module RedactingLogger
   module Version
-    VERSION = "0.0.4"
+    VERSION = "1.0.0"
   end
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,6 +2,6 @@
 
 module RedactingLogger
   module Version
-    VERSION = "1.0.0"
+    VERSION = "0.1.0"
   end
 end


### PR DESCRIPTION
This pull request makes it so that this Gem follows the same initialization inputs are the core Logger library. This will make it a lot easier to integrate with other frameworks in the future.